### PR TITLE
Added HLError to blanket header.

### DIFF
--- a/HLSpriteKit/HLSpriteKit.h
+++ b/HLSpriteKit/HLSpriteKit.h
@@ -9,6 +9,7 @@
 #import "HLAction.h"
 #import "HLComponentNode.h"
 #import "HLEmitterStore.h"
+#import "HLError.h"
 #import "HLGestureTarget.h"
 #import "HLGridNode.h"
 #import "HLItemContentNode.h"


### PR DESCRIPTION
Everything in Carthage looks good except for a warning that HLError is missing from the blanket header. Simple solution.

<img width="265" alt="screen shot 2016-09-13 at 12 45 15 am" src="https://cloud.githubusercontent.com/assets/967591/18465382/5f6032d4-794b-11e6-9dbf-74c337c1c6a8.png">
